### PR TITLE
Updated statement order so /src is created with correct ownership

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM ocaml/opam:debian-11-ocaml-5.0@sha256:373f76b0c929c2e27fd1ef98695c6604d048bdaf214579e8ec1efde263a42b27 AS build
 RUN sudo apt-get update && sudo apt-get install libev-dev capnproto m4 pkg-config libsqlite3-dev libgmp-dev graphviz -y --no-install-recommends
 RUN cd ~/opam-repository && git fetch -q origin master && git reset --hard e10b6ec1ad58b6faa39283ba79fe31b19b2a1897 && opam update
-WORKDIR /src
 COPY --chown=opam multicoretests-ci.opam multicoretests-ci-lib.opam /src/
+WORKDIR /src
 RUN opam-2.1 install -y --deps-only .
 ADD --chown=opam . .
 RUN opam-2.1 exec -- dune build ./_build/install/default/bin/multicoretests-ci


### PR DESCRIPTION
If `WORKDIR` creates `/src` then ownership is `root` rather than `opam`.  With this new statement order, `COPY` will create `/src` and set the ownership.