### PR TITLE
Automatically collapse refs in UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,14 +10,14 @@ You can observe the results of the tests on GitHub on the corresponding commit, 
 
 The current platforms are:
 
-- MacOS, ARM64, OCaml 5.0
-- MacOS, ARM64, OCaml 5.1~alpha1
-- MacOS, ARM64, OCaml 5.2
-- Linux*, ARM64, OCaml 5.0
-- Linux*, ARM64, OCaml 5.1
-- Linux*, ARM64, OCaml 5.2
-- Linux*, S390x, OCaml 5.1
-- Linux*, S390x, OCaml 5.2
+- MacOS, ARM64, OCaml 5.0.0
+- MacOS, ARM64, OCaml 5.1.0~alpha2
+- MacOS, ARM64, OCaml 5.2.0+trunk
+- Linux*, ARM64, OCaml 5.0.0
+- Linux*, ARM64, OCaml 5.1.0+trunk
+- Linux*, ARM64, OCaml 5.2.0+trunk
+- Linux*, S390x, OCaml 5.1.0+trunk
+- Linux*, S390x, OCaml 5.2.0+trunk
 
 *Specifically Debian 11.
 

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -4,7 +4,7 @@ open Lwt.Infix
 module Platform = Conf.Platform
 
 let platforms = Conf.platforms ()
-let jobs = Hashtbl.create 128
+let jobs = Hashtbl.create 512
 
 let opam_repo_commit =
   let repo =
@@ -30,7 +30,6 @@ let record_job repo commit (platform : Platform.t) build =
         (Platform.label platform, (state, job_id))
 
 let build_with_docker ?ocluster ~opam_repo_commit repo commit =
-  (* Cartesian product of platforms and desired OCaml versions *)
   let builds =
     List.map
       (fun platform ->
@@ -63,7 +62,7 @@ let forall_refs ~installations fn =
         @@ fun repo ->
         let refs = Current_github.Api.Repo.ci_refs repo in
         refs
-        |> Current.list_iter (module Current_github.Api.Commit) @@ fun head ->
+        |> Current.list_iter ~collapse_key:"ref" (module Current_github.Api.Commit) @@ fun head ->
            let repo = Current.map Current_github.Api.Commit.repo_id head in
            fn repo head
 


### PR DESCRIPTION
Without this, refs are automatically unfolded showing every build, which can make it very difficult to find the PR/branch you're interested in when there are many (as is the case in [ocaml-multicore/multicoretests](https://github.com/ocaml-multicore/multicoretests)).

<img width="433" alt="Screenshot 2023-06-09 at 13 54 22" src="https://github.com/ocurrent/multicoretests-ci/assets/13054139/d5d3c355-806b-4eae-8bf0-1f24b708d498">

(Also updates the README and bumps the size of the jobs hash table.)