### PR TITLE
Allow searching of jobs by commit hash

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -33,12 +33,11 @@ let build_with_docker ?ocluster ~opam_repo_commit commit =
     let build =
       match ocluster with
       (* | None -> Build.v commit *)
-      | None -> failwith "Oops"
+      | None -> failwith "Local building not supported"
       | Some ocluster ->
           Cluster_build.v ~ocluster ~platform ~opam_repo_commit commit
     in
     let _ = record_job commit platform build in
-    (* Current.pair build record |> Current.map fst *)
     build
   in
   List.map

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -6,6 +6,7 @@ module Platform = Conf.Platform
 let platforms = Conf.platforms ()
 let jobs = Hashtbl.create 512
 
+(** Latest commit of opam repository *)
 let opam_repo_commit =
   let repo =
     { Current_github.Repo_id.owner = "ocaml"; name = "opam-repository" }
@@ -16,41 +17,37 @@ let get_job_id x =
   let+ md = Current.Analysis.metadata x in
   match md with Some { Current.Metadata.job_id; _ } -> job_id | None -> None
 
-let record_job repo commit (platform : Platform.t) build =
+let record_job commit (platform : Platform.t) build =
   let+ state = Current.state ~hidden:true build
   and+ job_id = get_job_id build
-  and+ repo
   and+ commit in
-  let { Current_github.Repo_id.owner; name } = repo in
   match job_id with
   | None -> ()
   | Some job_id ->
       Hashtbl.add jobs
-        (owner, name, Current_git.Commit.hash commit)
-        (Platform.label platform, (state, job_id))
+        (Current_git.Commit.hash commit)
+        (Platform.label platform, state, job_id)
 
-let build_with_docker ?ocluster ~opam_repo_commit repo commit =
-  let builds =
-    List.map
-      (fun platform ->
-        let build =
-          match ocluster with
-          (* | None -> Build.v commit *)
-          | None -> failwith "Oops"
-          | Some ocluster ->
-              Cluster_build.v ~ocluster ~platform ~opam_repo_commit commit
-        in
-        (* Is this OK? Don't currents need to be bound or something?? IDK *)
-        let (_ : unit Current.t) = record_job repo commit platform build in
-        build)
-      platforms
+let build_with_docker ?ocluster ~opam_repo_commit commit =
+  let build platform =
+    let build =
+      match ocluster with
+      (* | None -> Build.v commit *)
+      | None -> failwith "Oops"
+      | Some ocluster ->
+          Cluster_build.v ~ocluster ~platform ~opam_repo_commit commit
+    in
+    let _ = record_job commit platform build in
+    (* Current.pair build record |> Current.map fst *)
+    build
   in
-  List.map2
-    (fun build platform ->
+  List.map
+    (fun platform ->
+      let build = build platform in
       let+ state = Current.state ~hidden:true build
       and+ job_id = get_job_id build in
-      (Platform.label platform, state, job_id))
-    builds platforms
+      (platform, state, job_id))
+    platforms
   |> Current.list_seq
 
 let forall_refs ~installations fn =
@@ -64,13 +61,24 @@ let forall_refs ~installations fn =
         refs
         |> Current.list_iter ~collapse_key:"ref"
              (module Current_github.Api.Commit)
-           @@ fun head ->
-           let repo = Current.map Current_github.Api.Commit.repo_id head in
-           fn repo head
+           @@ fun head -> fn head
 
-let v_ref ?ocluster ~opam_repo_commit repo head =
-  Current_git.fetch (Current.map Current_github.Api.Commit.id head)
-  |> build_with_docker ?ocluster ~opam_repo_commit repo
+let v_ref ?ocluster ~opam_repo_commit head =
+  let builds =
+    Current_git.fetch (Current.map Current_github.Api.Commit.id head)
+    |> build_with_docker ?ocluster ~opam_repo_commit
+  in
+  let hash = Current.map Current_github.Api.Commit.hash head in
+  Current.pair builds hash
+  |> Current.map (fun (builds, hash) ->
+         List.iter
+           (fun (platform, _, job_id) ->
+             Option.iter (fun id -> Commits.record_job platform hash id) job_id)
+           builds;
+         builds)
+  |> Current.map
+       (List.map (fun (platform, state, job_id) ->
+            (Platform.label platform, state, job_id)))
   |> Github.status_of_state
   |> Current_github.Api.CheckRun.set_status head "Multicoretests-CI"
 
@@ -82,8 +90,9 @@ let v ?ocluster ~app () =
   let installations = Current_github.App.installations app in
   forall_refs ~installations (v_ref ?ocluster ~opam_repo_commit)
 
-let get_job_ids ~owner ~name ~hash =
-  [ snd @@ snd @@ Hashtbl.find jobs (owner, name, hash) ]
+let get_job_ids ~owner:_ ~name:_ ~hash =
+  let _, _, job_id = Hashtbl.find jobs hash in
+  [ job_id ]
 
 let run_capnp capnp_listen_address =
   let listen_address =
@@ -110,10 +119,12 @@ let main () config mode app capnp_listen_address github_auth submission_uri =
          else Github.has_role
        in
        let secure_cookies = github_auth <> None in
+       Commits.init ();
        let routes =
          Github.webhook_route ~engine ~get_job_ids ~webhook_secret
          :: Github.login_route github_auth
          :: Current_web.routes engine
+         @ Commits.routes ()
        in
        let site =
          Current_web.Site.v ?authn ~has_role ~secure_cookies

--- a/lib/commits.ml
+++ b/lib/commits.ml
@@ -29,11 +29,13 @@ module Jobs = struct
               PRIMARY KEY (label, hash, job_id)
             );|})
 
-  let get_job_ids hash_fragment =
+  let get_jobs hash_prefix =
     let t = Lazy.force db in
     (* The string 'hash%' matches prefix *)
-    let hash_infix = Printf.sprintf "%s%%" hash_fragment in
-    Db.query t.get_job_ids Sqlite3.Data.[ TEXT hash_infix ]
+    let hash_prefix =
+      Option.value ~default:"" hash_prefix |> Printf.sprintf "%s%%"
+    in
+    Db.query t.get_job_ids Sqlite3.Data.[ TEXT hash_prefix ]
     |> List.map @@ function
        | Sqlite3.Data.[ TEXT label; TEXT hash; TEXT id ] -> (label, hash, id)
        | row -> Fmt.failwith "get_job_ids: invalid row %a" Db.dump_row row
@@ -48,29 +50,136 @@ let record_job platform hash job_id =
   let t = Lazy.force Jobs.db in
   Db.exec t.record_job Sqlite3.Data.[ TEXT label; TEXT hash; TEXT job_id ]
 
-let render_commit hash =
-  let job_ids = Jobs.get_job_ids hash in
-  let open Tyxml_html in
-  let f (label, hash, id) =
-    let link = Printf.sprintf "http://localhost:8080/job/%s" id in
-    let text = Printf.sprintf "%s - commit %s" label hash in
-    p [ a ~a:[ a_href link ] [ txt text ] ]
-  in
-  Ok (List.map f job_ids)
+open Tyxml_html
 
-let handle () hash =
+let string_param name uri =
+  match Uri.get_query_param uri name with
+  | None | Some "" -> None
+  | Some x -> Some x
+
+let string_option ~placeholder ~title name value =
+  let value = Option.value value ~default:"" in
+  input
+    ~a:
+      [
+        a_name name;
+        a_input_type `Text;
+        a_value value;
+        a_placeholder placeholder;
+        a_title title;
+      ]
+    ()
+
+let enum_option ~choices name (value : string option) =
+  let value = Option.value value ~default:"" in
+  let choices = "" :: choices in
+  select
+    ~a:[ a_name name ]
+    (choices
+    |> List.map (fun form_value ->
+           let sel = if form_value = value then [ a_selected () ] else [] in
+           let label = if form_value = "" then "(any)" else form_value in
+           option ~a:(a_value form_value :: sel) (txt label)))
+
+let commit_tip = "Any prefix of the commit hash can be used here."
+
+let filter_jobs ?os ?arch ?version jobs =
+  let optional_filter f input =
+    match Option.map f input with Some b -> b | None -> true
+  in
+  let f (label, _, _) =
+    let open Astring in
+    optional_filter (fun os -> String.is_infix ~affix:os label) os
+    && optional_filter (fun arch -> String.is_infix ~affix:arch label) arch
+    && optional_filter
+         (fun version -> String.is_infix ~affix:version label)
+         version
+  in
+  List.filter f jobs
+
+let render_page ctx =
+  let uri = Cohttp.Request.uri @@ Current_web.Context.request ctx in
+  let render_row (label, hash, id) =
+    let link = Printf.sprintf "http://localhost:8080/job/%s" id in
+    tr
+      [
+        td [ txt label ];
+        td [ a ~a:[ a_href link ] [ txt id ] ];
+        td [ txt hash ];
+      ]
+  in
+  let hash = string_param "hash" uri in
+  let os = string_param "os" uri in
+  let arch = string_param "arch" uri in
+  let version = string_param "version" uri in
+  (* Sorted in newest-first order, by lexicographic ordering on job ID: [YYYY-MM-DD/HHMMSS-...] *)
+  let jobs =
+    Jobs.get_jobs hash
+    |> filter_jobs ?os ?arch ?version
+    |> List.sort (fun (_, _, id0) (_, _, id1) -> -String.compare id0 id1)
+  in
+  let content =
+    if jobs = [] then [ txt "No jobs satisfy these criteria." ]
+    else
+      [
+        form
+          ~a:[ a_action "/commits"; a_method `Post ]
+          [
+            table
+              ~a:[ a_class [ "table" ] ]
+              ~thead:
+                (thead
+                   [
+                     tr
+                       [
+                         th [ txt "Platform" ]; th [ txt "Job" ]; th [ txt "Hash" ];
+                       ];
+                   ])
+              (List.map render_row jobs);
+          ];
+      ]
+  in
+  [
+    form
+      ~a:[ a_action "/commits"; a_method `Get ]
+      [
+        ul
+          ~a:[ a_class [ "query-form" ] ]
+          [
+            li
+              [
+                txt "Operating system:";
+                enum_option ~choices:[ "linux"; "macos" ] "os" os;
+              ];
+            li
+              [
+                txt "Architecture:";
+                enum_option ~choices:[ "arm64"; "s390x" ] "arch" arch;
+              ];
+            li
+              [
+                txt "OCaml version:";
+                enum_option ~choices:[ "5.0"; "5.1"; "5.2" ] "version" version;
+              ];
+            li
+              [
+                txt "Commit hash:";
+                string_option "hash" hash ~placeholder:"" ~title:commit_tip;
+              ];
+            li [ input ~a:[ a_input_type `Submit; a_value "Submit" ] () ];
+          ];
+      ];
+  ]
+  @ content
+
+let handle =
   object
     inherit Current_web.Resource.t
+    method! nav_link = Some "Commit search"
     val! can_get = `Viewer
 
     method! private get context =
-      let response =
-        match render_commit hash with
-        | Ok page -> page
-        | Error msg ->
-            Tyxml_html.[ txt "An error occured:"; br (); i [ txt msg ] ]
-      in
-      Current_web.Context.respond_ok context response
+      Current_web.Context.respond_ok context (render_page context)
   end
 
-let routes () = Routes.[ (s "commits" / str /? nil) @--> handle () ]
+let routes () = Routes.[ (s "commits" /? nil) @--> handle ]

--- a/lib/commits.ml
+++ b/lib/commits.ml
@@ -1,0 +1,76 @@
+module Db = Current.Db
+
+module Jobs = struct
+  type t = { get_job_ids : Sqlite3.stmt; record_job : Sqlite3.stmt }
+
+  let db =
+    lazy
+      (let db = Lazy.force Db.v in
+       Current_cache.Db.init ();
+       let get_job_ids =
+         Sqlite3.prepare db
+           "SELECT label, hash, job_id FROM ci_build_index WHERE hash LIKE ?"
+       in
+       let record_job =
+         Sqlite3.prepare db
+           "INSERT OR REPLACE INTO ci_build_index (label, hash, job_id) VALUES \
+            (?, ?, ?)"
+       in
+       { get_job_ids; record_job })
+
+  let db_init =
+    lazy
+      (let db = Lazy.force Db.v in
+       Sqlite3.prepare db
+         {|CREATE TABLE IF NOT EXISTS ci_build_index (
+              label  TEXT NOT NULL,
+              hash   TEXT NOT NULL,
+              job_id TEXT NOT NULL,
+              PRIMARY KEY (label, hash, job_id)
+            );|})
+
+  let get_job_ids hash_fragment =
+    let t = Lazy.force db in
+    (* The string '%hash%' matches infix *)
+    let hash_infix = Printf.sprintf "%%%s%%" hash_fragment in
+    Db.query t.get_job_ids Sqlite3.Data.[ TEXT hash_infix ]
+    |> List.map @@ function
+       | Sqlite3.Data.[ TEXT label; TEXT hash; TEXT id ] -> (label, hash, id)
+       | row -> Fmt.failwith "get_job_ids: invalid row %a" Db.dump_row row
+end
+
+let init () =
+  let t = Lazy.force Jobs.db_init in
+  Db.exec t []
+
+let record_job platform hash job_id =
+  let label = Conf.Platform.label platform in
+  let t = Lazy.force Jobs.db in
+  Db.exec t.record_job Sqlite3.Data.[ TEXT label; TEXT hash; TEXT job_id ]
+
+let render_commit hash =
+  let job_ids = Jobs.get_job_ids hash in
+  let open Tyxml_html in
+  let f (label, hash, id) =
+    let link = Printf.sprintf "http://localhost:8080/job/%s" id in
+    let text = Printf.sprintf "%s - commit %s" label hash in
+    p [ a ~a:[ a_href link ] [ txt text ] ]
+  in
+  Ok (List.map f job_ids)
+
+let handle () hash =
+  object
+    inherit Current_web.Resource.t
+    val! can_get = `Viewer
+
+    method! private get context =
+      let response =
+        match render_commit hash with
+        | Ok page -> page
+        | Error msg ->
+            Tyxml_html.[ txt "An error occured:"; br (); i [ txt msg ] ]
+      in
+      Current_web.Context.respond_ok context response
+  end
+
+let routes () = Routes.[ (s "commits" / str /? nil) @--> handle () ]

--- a/lib/commits.ml
+++ b/lib/commits.ml
@@ -31,8 +31,8 @@ module Jobs = struct
 
   let get_job_ids hash_fragment =
     let t = Lazy.force db in
-    (* The string '%hash%' matches infix *)
-    let hash_infix = Printf.sprintf "%%%s%%" hash_fragment in
+    (* The string 'hash%' matches prefix *)
+    let hash_infix = Printf.sprintf "%s%%" hash_fragment in
     Db.query t.get_job_ids Sqlite3.Data.[ TEXT hash_infix ]
     |> List.map @@ function
        | Sqlite3.Data.[ TEXT label; TEXT hash; TEXT id ] -> (label, hash, id)

--- a/lib/conf.ml
+++ b/lib/conf.ml
@@ -116,8 +116,7 @@ let pool_of_arch a =
   (* | `X86_64 | `I386 -> "linux-x86_64" *)
   | `Aarch32 | `Aarch64 -> "linux-arm64"
   | `S390x -> "linux-s390x"
-  | `Ppc64le -> "linux-ppc64"
-     (* | `Riscv64 -> "linux-riscv64" *)
+  | `Ppc64le -> "linux-ppc64" (* | `Riscv64 -> "linux-riscv64" *)
   | `X86_64 | `I386 | `Riscv64 ->
       failwith
         (Printf.sprintf "Unsupported architecture: %s" (OV.string_of_arch a))


### PR DESCRIPTION
Adds a tab called "Commit search" to the OCurrent UI that allows searching a new database that associates hashes with job IDs and platforms. The schema is:
```
ci_build_index (
  label  TEXT NOT NULL,
  hash   TEXT NOT NULL,
  job_id TEXT NOT NULL,
  PRIMARY KEY (label, hash, job_id)
)
```
where `label` is, for example, `linux-s390x-5.1`. This allows filtering by OS, architecture, and OCaml version.

Jobs are sorted by newest-to-oldest (lexicographically on the job ID), and clicking on the job ID for a given row takes you to the logs of that job.

<img width="1289" alt="Screenshot 2023-06-17 at 11 55 21" src="https://github.com/ocurrent/multicoretests-ci/assets/13054139/d68f661d-8d81-4e80-94d8-d2c228e0954b">
