### PR TITLE
Print OCaml and OPAM versions in spec file

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ You can observe the results of the tests on GitHub on the corresponding commit, 
 The current platforms are:
 
 - MacOS, ARM64, OCaml 5.0.0
-- MacOS, ARM64, OCaml 5.1.0~alpha2
+- MacOS, ARM64, OCaml 5.1.0~beta1
 - MacOS, ARM64, OCaml 5.2.0+trunk
 - Linux*, ARM64, OCaml 5.0.0
 - Linux*, ARM64, OCaml 5.1.0+trunk

--- a/lib/spec.ml
+++ b/lib/spec.ml
@@ -121,6 +121,7 @@ let v opam_repo_commit base os arch =
   let opam_repo_commit = Current_git.Commit_id.hash opam_repo_commit in
   stage ~from:base
     (env "QCHECK_MSG_INTERVAL" "60"
+     :: run "ocaml --version && opam --version"
      :: user_unix ~uid:1000 ~gid:1000
      :: install_project_deps opam_repo_commit os arch
     @ [ copy [ "." ] ~dst:home_dir; run_build ])


### PR DESCRIPTION
Useful for seeing the specific versions being used in a build.