### PR TITLE
Revert #14

### DIFF
--- a/lib/spec.ml
+++ b/lib/spec.ml
@@ -121,7 +121,6 @@ let v opam_repo_commit base os arch =
   let opam_repo_commit = Current_git.Commit_id.hash opam_repo_commit in
   stage ~from:base
     (env "QCHECK_MSG_INTERVAL" "60"
-     :: run "ocaml --version && opam --version"
      :: user_unix ~uid:1000 ~gid:1000
      :: install_project_deps opam_repo_commit os arch
     @ [ copy [ "." ] ~dst:home_dir; run_build ])


### PR DESCRIPTION
Command `ocaml` is for some reason not accessible by the worker, and the `opam` version is less useful.