### PR TITLE
Print OCaml and OPAM versions in spec file with appropriate environment

### DIFF
--- a/lib/spec.ml
+++ b/lib/spec.ml
@@ -121,6 +121,7 @@ let v opam_repo_commit base os arch =
   let opam_repo_commit = Current_git.Commit_id.hash opam_repo_commit in
   stage ~from:base
     (env "QCHECK_MSG_INTERVAL" "60"
+     :: run "eval $(opam env) && ocaml --version && opam --version"
      :: user_unix ~uid:1000 ~gid:1000
      :: install_project_deps opam_repo_commit os arch
     @ [ copy [ "." ] ~dst:home_dir; run_build ])


### PR DESCRIPTION
Retry of #14.

Fixed by pre-running `eval $(opam env)` according to advice in https://github.com/ocurrent/multicoretests-ci/pull/15#issuecomment-1621522740.