### PR TITLE
Mimick GitHub actions printing

### DIFF
--- a/lib/spec.ml
+++ b/lib/spec.ml
@@ -121,7 +121,7 @@ let v opam_repo_commit base os arch =
   let opam_repo_commit = Current_git.Commit_id.hash opam_repo_commit in
   stage ~from:base
     (env "QCHECK_MSG_INTERVAL" "60"
-     :: run "eval $(opam env) && ocaml --version && opam --version"
      :: user_unix ~uid:1000 ~gid:1000
      :: install_project_deps opam_repo_commit os arch
-    @ [ copy [ "." ] ~dst:home_dir; run_build ])
+    @ [ run "eval $(opam env) && opam exec -- ocamlc -config && opam config list && opam list --columns=name,installed-version,repository,synopsis-or-target";
+        copy [ "." ] ~dst:home_dir; run_build ])


### PR DESCRIPTION
#14 and #16 got me investigating what version printing @shym added in GitHub actions:
  https://github.com/ocaml-multicore/multicoretests/blob/main/.github/workflows/common.yml#L281

This little PR takes a step in that direction:
- printing both the compiler and opam configuration
- along with all installed versions (moved after dependency installation)

I think it this can be useful, e.g., for this `trunk` bytecode workflow
https://github.com/ocaml-multicore/multicoretests/actions/runs/5464994563/jobs/9947798674#step:14:34
`native_compiler: false` confirms that this is indeed is a bytecode build,
and that can confirm that the arm64, s390x, and ppc64 runs are indeed native as we expect.

For now, I omitted `opam exec -- dune printenv`