### PR TITLE
Build `ci` dune alias rather than `runtest`

### DIFF
--- a/lib/build.ml
+++ b/lib/build.ml
@@ -41,7 +41,7 @@ module Op = struct
  (run
   (network host)
   (shell "opam install . --deps-only --with-test -y"))
- (run (shell "eval $(opam env) && dune build && dune runtest -j1 --no-buffer --display=quiet")))
+ (run (shell "eval $(opam env) && dune build && dune runtest -j1 --no-buffer --display=quiet test/ && dune build @ci -j1 --no-buffer --display=quiet --error-reporting=twice")))
     |}
 
   let run { docker_context; pool; build_timeout } job commit () =

--- a/lib/spec.ml
+++ b/lib/spec.ml
@@ -111,7 +111,8 @@ let v opam_repo_commit base os arch =
        Run with [-j1] to run tests sequentially, as tests are timing- and load-sensitive *)
     let build_and_test =
       "eval $(opam env) && dune build && dune runtest -j1 --no-buffer \
-       --display=quiet"
+       --display=quiet test/ && dune build @ci -j1 --no-buffer --display=quiet \
+       --error-reporting=twice"
     in
     match os with
     | `Macos -> run "cd ./src && %s" build_and_test


### PR DESCRIPTION
This PR aligns what is done in both CI systems.