### PR TITLE
Specify Docker images with hash

### DIFF
--- a/lib/cluster_build.ml
+++ b/lib/cluster_build.ml
@@ -22,6 +22,7 @@ module Op = struct
       arch : Ocaml_version.arch;
       version : string;
       distro : string;
+      docker_tag : string;
       commit : Current_git.Commit_id.t;
       opam_repo_commit : Current_git.Commit_id.t;
     }
@@ -63,8 +64,9 @@ module Op = struct
             (Printf.sprintf "macos-homebrew-ocaml-%s" k.version)
             `Macos k.arch
       | Some d ->
-          let base = Printf.sprintf "ocaml/opam:debian-11-ocaml-%s" k.version in
-          Spec.v k.opam_repo_commit base (Conf.DD.os_family_of_distro d) k.arch
+          Spec.v k.opam_repo_commit k.docker_tag
+            (Conf.DD.os_family_of_distro d)
+            k.arch
     in
     let action = Cluster_api.Submission.obuilder_build spec in
     let src = Current_git.Commit_id.(repo k.commit, [ hash k.commit ]) in
@@ -98,12 +100,25 @@ let config ?timeout sr =
   { connection; timeout; on_cancel = ignore }
 
 let build ~ocluster ~platform ~opam_repo_commit commit =
-  let { Platform.pool; arch; distro; ocaml_version = version; _ } = platform in
+  let {
+    Platform.pool;
+    arch;
+    distro;
+    docker_tag;
+    docker_tag_with_digest;
+    ocaml_version = version;
+    _;
+  } =
+    platform
+  in
   Current.component "build %s" (Platform.label platform)
   |> let> commit and> opam_repo_commit in
      let commit = Current_git.Commit.id commit in
+     let docker_tag =
+       match docker_tag_with_digest with None -> docker_tag | Some d -> d
+     in
      BC.run ocluster
-       { pool; arch; distro; version; commit; opam_repo_commit }
+       { pool; arch; distro; docker_tag; version; commit; opam_repo_commit }
        ()
 
 let get_job_id x =

--- a/lib/spec.ml
+++ b/lib/spec.ml
@@ -73,8 +73,8 @@ let install_project_deps opam_repo_commit os arch =
     | Some home_dir -> [ Obuilder_spec.workdir home_dir ]
     | None -> [])
   @ [
-      run "%s -f %s/bin/opam-2.1 %s/bin/opam && opam init --reinit -ni" ln
-        prefix prefix;
+      run ~network "%s -f %s/bin/opam-2.1 %s/bin/opam && opam init --reinit -ni"
+        ln prefix prefix;
     ]
   @ (match home_dir with
     | Some home_dir -> [ workdir home_dir; run "sudo chown opam /src" ]


### PR DESCRIPTION
Explicitly choose the Docker images with the latest hash for each platform, ensuring they stay up-to-date.