### PR TITLE
Add FreeBSD OCaml 5.0 and set docker base image schedule to 1 day

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,14 @@ You can observe the results of the tests on GitHub on the corresponding commit, 
 The current platforms are:
 
 - MacOS, ARM64, OCaml 5.0.0
-- MacOS, ARM64, OCaml 5.1.0~beta1
+- MacOS, ARM64, OCaml 5.1.0
 - MacOS, ARM64, OCaml 5.2.0+trunk
+- FreeBSD, X86-64, OCaml 5.0.0
+- FreeBSD, X86-64, OCaml 5.1.0
 - Linux*, ARM64, OCaml 5.0.0
-- Linux*, ARM64, OCaml 5.1.0+trunk
+- Linux*, ARM64, OCaml 5.1.0
 - Linux*, ARM64, OCaml 5.2.0+trunk
-- Linux*, S390x, OCaml 5.1.0+trunk
+- Linux*, S390x, OCaml 5.1.0
 - Linux*, S390x, OCaml 5.2.0+trunk
 - Linux*, PPC64LE, OCaml 5.2.0+trunk
 

--- a/lib/conf.ml
+++ b/lib/conf.ml
@@ -133,7 +133,16 @@ let freebsd_platforms : Platform.t list =
       pool = "freebsd-x86_64";
       distro = "freebsd";
       arch = `X86_64;
-      docker_tag = "homebrew/brew";
+      docker_tag = "freebsd";
+      docker_tag_with_digest = None;
+      ocaml_version = "5.0";
+    };
+    {
+      builder = Builders.local;
+      pool = "freebsd-x86_64";
+      distro = "freebsd";
+      arch = `X86_64;
+      docker_tag = "freebsd";
       docker_tag_with_digest = None;
       ocaml_version = "5.1";
     };
@@ -172,7 +181,7 @@ let image_of_distro = function
         (Printf.sprintf "Unhandled distro: %s" (DD.tag_of_distro (d :> DD.t)))
 
 let get_digests platforms =
-  let schedule = Current_cache.Schedule.v ~valid_for:(Duration.of_day 30) () in
+  let schedule = Current_cache.Schedule.v ~valid_for:(Duration.of_day 1) () in
   let f (p : Platform.t) =
     match Platform.distro_to_os p.distro with
     | "linux" ->


### PR DESCRIPTION
#26 added only OCaml 5.1 FreeBSD, this PR adds 5.0 as well.

The schedule for pulling the Docker base images was every 30 days, which is not fast enough for changing OCaml versions. This PR changes the schedule to update every day. The base images themselves update every 7 days, so the 1 day-schedule is just for responsiveness; without changes to the base image the rest of the pipeline will not be triggered.

I believe out-of-date base images is a contributing factor to #23, so we'll see if this change helps.