### PR TITLE
Remove 5.0 workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,10 @@ You can observe the results of the tests on GitHub on the corresponding commit, 
 
 The current platforms are:
 
-- MacOS, ARM64, OCaml 5.0.0
 - MacOS, ARM64, OCaml 5.1.0
 - MacOS, ARM64, OCaml 5.2.0+trunk
-- FreeBSD, X86-64, OCaml 5.0.0
 - FreeBSD, X86-64, OCaml 5.1.0
 - FreeBSD, X86-64, OCaml 5.2.0
-- Linux*, ARM64, OCaml 5.0.0
 - Linux*, ARM64, OCaml 5.1.0
 - Linux*, ARM64, OCaml 5.2.0+trunk
 - Linux*, S390x, OCaml 5.1.0

--- a/lib/conf.ml
+++ b/lib/conf.ml
@@ -108,7 +108,7 @@ let macos_platforms : Platform.t list =
           docker_tag_with_digest = None;
           ocaml_version;
         })
-    [ "5.0"; "5.1"; "5.2" ]
+    [ "5.1"; "5.2" ]
 
 let freebsd_platforms : Platform.t list =
   List.map
@@ -123,7 +123,7 @@ let freebsd_platforms : Platform.t list =
           docker_tag_with_digest = None;
           ocaml_version;
         })
-    [ "5.0"; "5.1"; "5.2" ]
+    [ "5.1"; "5.2" ]
 
 let pool_of_arch : arch -> string = function
   (* | `X86_64 | `I386 -> "linux-x86_64"
@@ -193,7 +193,6 @@ let platforms () =
   in
   let platforms =
     [
-      ("5.0", `Debian `V11, `Aarch64);
       ("5.1", `Debian `V11, `Aarch64);
       ("5.2", `Debian `V11, `Aarch64);
       ("5.1", `Debian `V11, `S390x);


### PR DESCRIPTION
5.1.0 is the current release with 5.2.0 to be released within the next month or so.
As such, 5.0 workflows are of becoming of less interest, compiler-testing-wise.
This PR therefore proposes to remove them, in the interest of saving needless CPU cycles.

CC @benmandrew @mtelvers 