### PR TITLE
Remove macOS workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,6 @@ You can observe the results of the tests on GitHub on the corresponding commit, 
 
 The current platforms are:
 
-- MacOS, ARM64, OCaml 5.1.0
-- MacOS, ARM64, OCaml 5.2.0+trunk
 - FreeBSD, X86-64, OCaml 5.1.0
 - FreeBSD, X86-64, OCaml 5.2.0
 - Linux*, ARM64, OCaml 5.1.0

--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ The current platforms are:
 - FreeBSD, X86-64, OCaml 5.1.0
 - FreeBSD, X86-64, OCaml 5.2.0
 - Linux*, ARM64, OCaml 5.1.0
-- Linux*, ARM64, OCaml 5.2.0+trunk
+- Linux*, ARM64, OCaml 5.2.0
 - Linux*, S390x, OCaml 5.1.0
-- Linux*, S390x, OCaml 5.2.0+trunk
-- Linux*, PPC64LE, OCaml 5.2.0+trunk
+- Linux*, S390x, OCaml 5.2.0
+- Linux*, PPC64LE, OCaml 5.2.0
 
 *Specifically Debian 11.
 

--- a/lib/conf.ml
+++ b/lib/conf.ml
@@ -87,29 +87,6 @@ module Platform = struct
   let pp = Fmt.of_to_string label
 end
 
-let macos_platforms : Platform.t list =
-  (* {
-       label = "macos-amd64";
-       builder = Builders.local;
-       pool = "macos-x86_64";
-       distro = "macos-homebrew";
-       arch = `X86_64;
-       docker_tag = "homebrew/brew";
-     }; *)
-  List.map
-    (fun ocaml_version ->
-      Platform.
-        {
-          builder = Builders.local;
-          pool = "macos-arm64";
-          distro = "macos-homebrew";
-          arch = `Aarch64;
-          docker_tag = "homebrew/brew";
-          docker_tag_with_digest = None;
-          ocaml_version;
-        })
-    [ "5.1"; "5.2" ]
-
 let freebsd_platforms : Platform.t list =
   List.map
     (fun ocaml_version ->
@@ -202,4 +179,4 @@ let platforms () =
     |> List.map (fun (ocaml_version, distro, arch) ->
            v ~arch distro ocaml_version)
   in
-  platforms @ macos_platforms @ freebsd_platforms |> get_digests
+  platforms @ freebsd_platforms |> get_digests


### PR DESCRIPTION
Since [GitHub actions now support macOS M1 runners](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources) it makes sense to collect them under one "CI backend".

I've thus opened https://github.com/ocaml-multicore/multicoretests/pull/458 to this effect.
To save CPU cycles we can thus remove the macOS runners from `multicoretests-ci`.

CC @benmandrew 