### PR TITLE
Remove 5.1.0 workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,8 @@ You can observe the results of the tests on GitHub on the corresponding commit, 
 
 The current platforms are:
 
-- FreeBSD, X86-64, OCaml 5.1.0
 - FreeBSD, X86-64, OCaml 5.2.0
-- Linux*, ARM64, OCaml 5.1.0
 - Linux*, ARM64, OCaml 5.2.0
-- Linux*, S390x, OCaml 5.1.0
 - Linux*, S390x, OCaml 5.2.0
 - Linux*, PPC64LE, OCaml 5.2.0
 

--- a/lib/conf.ml
+++ b/lib/conf.ml
@@ -100,7 +100,7 @@ let freebsd_platforms : Platform.t list =
           docker_tag_with_digest = None;
           ocaml_version;
         })
-    [ "5.1"; "5.2" ]
+    [ "5.2" ]
 
 let pool_of_arch : arch -> string = function
   (* | `X86_64 | `I386 -> "linux-x86_64"
@@ -170,9 +170,7 @@ let platforms () =
   in
   let platforms =
     [
-      ("5.1", `Debian `V11, `Aarch64);
       ("5.2", `Debian `V11, `Aarch64);
-      ("5.1", `Debian `V11, `S390x);
       ("5.2", `Debian `V11, `S390x);
       ("5.2", `Debian `V11, `Ppc64le);
     ]


### PR DESCRIPTION
Testing-wise, we are concerned with the status of 5.2.0 and `trunk` (soon to be forked as 5.3.0) and thus less with 5.1.0.
This PR thus removes the 5.1.0 workflows to save needless CPU cycles.

(It also needs pushing to the `live` branch)